### PR TITLE
Eliminate deprecated config params

### DIFF
--- a/HireIQ-Changes.md
+++ b/HireIQ-Changes.md
@@ -2,6 +2,13 @@
 
 Quick summary of changes made by HireIQ post-fork:
 
+## v2.39.102
+
+- Modify the template for the ini file to remove deprecated fields `capture_params`
+  and `ignored_params`, replaced with `attributes.[exclude|include]`.
+
+## v2.39.101
+
 - Allow attribute overrides in the style of the old Chef 11 OpsWorks recipes.
 - Unpin version of 'ark' as it would conflict with HireIQ's pin
 - Add trusted=true to apt_repository to stop Chef crash on Ubuntu 18.04, repository not signed.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,5 +76,8 @@ default['newrelic']['application_monitoring']['framework'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['remove_trailing_path'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['functions'] = nil
 default['newrelic']['application_monitoring']['webtransaction']['name']['files'] = nil
+default['newrelic']['application_monitoring']['attributes_enabled'] = nil
+default['newrelic']['application_monitoring']['attributes_include'] = nil
+default['newrelic']['application_monitoring']['attributes_exclude'] = nil
 
 include_attribute 'newrelic::customize'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'development@davidjoos.com'
 license 'MIT'
 description 'Installs/Configures New Relic'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.39.101'
+version '2.39.102'
 chef_version '>= 0.10.0' if respond_to?(:chef_version)
 
 %w[debian ubuntu redhat centos fedora scientific amazon windows smartos oracle].each do |os|

--- a/recipes/python_agent.rb
+++ b/recipes/python_agent.rb
@@ -33,4 +33,7 @@ newrelic_agent_python 'new python agent' do
   cross_application_tracer_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['cross_application_tracer']['enable']) unless node['newrelic']['application_monitoring']['cross_application_tracer']['enable']
   feature_flag node['newrelic']['python_agent']['feature_flag'] unless node['newrelic']['python_agent']['feature_flag'].nil?
   thread_profiler_enable NewRelic.to_boolean(node['newrelic']['application_monitoring']['thread_profiler']['enable']) unless node['newrelic']['application_monitoring']['thread_profiler']['enable'].nil?
+  attributes_enabled NewRelic.to_boolean(node['newrelic']['application_monitoring']['attributes_enabled']) unless node['newrelic']['application_monitoring']['attributes_enabled'].nil?
+  attributes_include node['newrelic']['application_monitoring']['attributes_include'] unless node['newrelic']['application_monitoring']['attributes_include'].nil?
+  attributes_exclude node['newrelic']['application_monitoring']['attributes_exclude'] unless node['newrelic']['application_monitoring']['attributes_exclude'].nil?
 end

--- a/resources/agent_python.rb
+++ b/resources/agent_python.rb
@@ -20,6 +20,8 @@ attribute :logfile, :kind_of => String, :default => '/tmp/newrelic-python-agent.
 attribute :loglevel, :kind_of => String, :default => 'info'
 attribute :daemon_ssl, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :high_security, :kind_of => [TrueClass, FalseClass], :default => false
+# capture_params and ignored_params are obsolete. Maintained for backward compat
+# with existing recipes, but will be ignored.
 attribute :capture_params, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :ignored_params, :kind_of => String, :default => ' '
 attribute :transaction_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
@@ -36,3 +38,6 @@ attribute :browser_monitoring_auto_instrument, :kind_of => [TrueClass, FalseClas
 attribute :cross_application_tracer_enable, :kind_of => [TrueClass, FalseClass], :default => true
 attribute :feature_flag, :kind_of => String, :default => nil
 attribute :python, :kind_of => String, :default => nil
+attribute :attributes_enabled, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :attributes_include, :kind_of => String, :default => ' '
+attribute :attributes_exclude, :kind_of => String, :default => ' '

--- a/templates/default/agent/python/newrelic.ini.erb
+++ b/templates/default/agent/python/newrelic.ini.erb
@@ -118,24 +118,34 @@ ssl = <%= @resource.daemon_ssl %>
 # proxy_user =
 # proxy_pass =
 
-# Tells the transaction tracer and error collector (when
-# enabled) whether or not to capture the query string for the
-# URL and send it as the request parameters for display in the
-# UI. When "true", it is still possible to exclude specific
-# values from being captured using the "ignored_params" setting.
-<% if @resource.capture_params.nil? %>
-capture_params = false
+# Capturing request parameters is off by default. To enable the
+# capturing of request parameters, first ensure that the setting
+# "attributes.enabled" is set to "true" (the default value), and
+# then add "request.parameters.*" to the "attributes.include"
+# setting. For details about attributes configuration, please
+# consult the documentation.
+<% if @resource.attributes_enabled.nil? %>
+attributes_enabled = false
 <% else %>
-capture_params = <%= @resource.capture_params %>
+attributes_enabled = <%= @resource.attributes_enabled %>
+<% end %>
+
+# Space separated list of variables that should be included from
+# the query string captured for display as the request
+# parameters in the UI.
+<% if @resource.attributes_include.nil? %>
+attributes_include =
+<% else %>
+attributes_include = <%= @resource.attributes_include %>
 <% end %>
 
 # Space separated list of variables that should be removed from
 # the query string captured for display as the request
 # parameters in the UI.
-<% if @resource.ignored_params.nil? %>
-ignored_params =
+<% if @resource.attributes_exclude.nil? %>
+attributes_exclude =
 <% else %>
-ignored_params = <%= @resource.ignored_params %>
+attributes_exclude = <%= @resource.attributes_exclude %>
 <% end %>
 
 # The transaction tracer captures deep information about slow


### PR DESCRIPTION
The configurations "capture_params" and "ignored_params" have been deprecated and are now generating warning because they are present. They have been replaced with the new "attributes" configuration.

https://www.pivotaltracker.com/story/show/166541892

https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration#attributes